### PR TITLE
Auth context

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ Toast Me
 - **Add Statement** > if user sign-in or out or not having username
 - **Note** > Tou can Sign-in & see your info in the inspect > Application > indexDB > firebaseLocalStorage
 
+### Auth-Context (react context API)
+
+- **Context** > provides a way to pass data through the component tree without having to pass props down manually at every level > make the User info all the app can use it > share data throughout the component tree
+- **.Provider** > using it will remove the idea of passing props
+  ```
+  <ThemeContext.**Provider** value="dark">
+  <HOME/>
+  </ThemeContext.**Provider**>
+  ```
+  - steps > Import createContext > const & make default value > round the app.tsx with it + the .Provider > import useContextHook from reate & pass the const as argument
+
 ## Extra
 
 - **Costume Snippets** > Make your short cut code like **rafce** > press Shift + command P > config Snippets > make like the doc's > https://code.visualstudio.com/docs/editor/userdefinedsnippets#_create-your-own-snippets
@@ -116,3 +127,4 @@ Toast Me
 - https://www.npmjs.com/package/react-firebase-hooks
 - https://firebase.google.com/docs/web/setup
 - https://react-hot-toast.com/
+- https://reactjs.org/docs/context.html

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,14 +1,11 @@
-import Image, { StaticImport } from "next/image";
+import Image from "next/image";
 import Link from "next/link";
-import React from "react";
+import { useContext } from "react";
+import { UserContext } from "../lib/context";
 
-type NavbarProps = {
-  user: {
-    photoURL: string | StaticImport;
-  };
-  username: string;
-};
-export default function Navbar({ user, username }: NavbarProps) {
+export default function Navbar() {
+  const userContext = useContext(UserContext); //* it will rerender every changes in the app for the context
+
   return (
     <nav className="navbar">
       <ul>
@@ -19,7 +16,7 @@ export default function Navbar({ user, username }: NavbarProps) {
         </li>
 
         {/* User is <signed-in> and <has> username */}
-        {username && (
+        {userContext?.username && (
           <>
             <li className="push-left">
               <Link href="/admin">
@@ -27,15 +24,14 @@ export default function Navbar({ user, username }: NavbarProps) {
               </Link>
             </li>
             <li>
-              <Link href={`/${username}`}>
-                <Image src={user?.photoURL} alt="user img" />
-              </Link>
+              {/* <Link href={`/${userContext.username}`}> */}
+              {/* <Image src={userContext.photoURL} alt="user img" />  */}
+              {/* </Link> */}
             </li>
           </>
         )}
-
         {/* User is <not> signed OR has <not> created username */}
-        {!username && (
+        {!userContext?.username && (
           <li>
             <Link href="/enter">
               <button className="btn-blue">Log in</button>

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,0 +1,15 @@
+// * Call it
+import { StaticImport } from "next/image";
+import { createContext } from "react";
+
+interface ContextProps {
+  photoURL?: string | StaticImport; //! Need to be fix typescript error
+  user: null | { photoURL: string | StaticImport } | {};
+  username: null | string;
+}
+// * Initialize the context will default value =({obj}) to use the value in the hole app
+export const UserContext = createContext<ContextProps | null>({
+  user: null,
+  username: null,
+  photoURL: "",
+});

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,19 +2,20 @@ import "../styles/globals.css";
 import type { AppProps } from "next/app";
 import Navbar from "../components/Navbar";
 import { Toaster } from "react-hot-toast";
+import { UserContext } from "../lib/context";
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <>
-      {/* Add the NavBar for all the components */}
-      <Navbar
-        user={{
-          photoURL: "",
-        }}
-        username={""}
-      />
-      <Component {...pageProps} />
-      <Toaster />
+      <UserContext.Provider
+        value={{ user: {}, username: "abdullah", photoURL: "" }}
+      >
+        {/* Add the NavBar for all the components */}
+        <Navbar />
+        <Component {...pageProps} />
+
+        <Toaster />
+      </UserContext.Provider>
     </>
   );
 }

--- a/pages/enter.tsx
+++ b/pages/enter.tsx
@@ -1,17 +1,19 @@
 import Image from "next/image";
 import { auth, googleAuthProvider } from "../lib/firebase";
 import GoogleImg from "../public/googleImg.png";
+import { useContext } from "react";
+import { UserContext } from "../lib/context";
 
 export default function EnterPage() {
-  const user = null;
-  const username = null;
+  //* Take all the user context
+  const userContext = useContext(UserContext);
 
   return (
     <main>
       {/* If the user Sign-in */}
-      {user ? (
+      {userContext?.user ? (
         // * If the user sign-in BUT have no username > Show the Form
-        !username ? (
+        !userContext.username ? (
           <UsernameForm />
         ) : (
           <SignOutButton /> //* else > user signed in, has username ==> <SignOutButton />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,6 @@
 import type { NextPage } from "next";
-import Head from "next/head";
-import Image from "next/image";
 import toast from "react-hot-toast";
 import Loader from "../components/Loader";
-import styles from "../styles/Home.module.css";
 
 const Home: NextPage = () => {
   return (


### PR DESCRIPTION
### Auth-Context (react context API)

- **Context** > provides a way to pass data through the component tree without having to pass props down manually at every level > make the User info all the app can use it > share data throughout the component tree
- **.Provider** > using it will remove the idea of passing props
  ```
  <ThemeContext.**Provider** value="dark">
  <HOME/>
  </ThemeContext.**Provider**>
  ```
  - steps > Import createContext > const & make default value > round the app.tsx with it + the .Provider > import useContextHook from reate & pass the const as argument